### PR TITLE
feat!: adopt mod-utils v6 (mod-hubspot v4)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,7 +13,7 @@
     source = 'layouts'
     target = 'layouts'
   [[module.imports]]
-    path = "github.com/gethinode/mod-utils/v5"
+    path = "github.com/gethinode/mod-utils/v6"
 
 [params.modules.hubspot]
   integration = "core"

--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -3,3 +3,15 @@ title: Test site
 description: Site to test module shortcode(s).
 date: 2024-09-28
 ---
+
+## Explicit portal and region
+
+{{< form form-id="1234-5678-90ab-cdef-1234567890ab" portal="12345678" region="eu1" >}}
+
+## Positional form ID, portal and region from site parameters
+
+{{< form "1234-5678-90ab-cdef-1234567890ab" >}}
+
+## Deprecated id argument
+
+{{< form id="1234-5678-90ab-cdef-1234567890ab" portal="12345678" region="eu1" >}}

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -3,7 +3,4 @@ module github.com/gethinode/mod-hubspot/exampleSite
 go 1.19
 
 require (
-	github.com/gethinode/mod-hubspot/v2 v2.0.1 // indirect
-	github.com/gethinode/mod-utils/v4 v4.21.6 // indirect
-	github.com/gethinode/mod-utils/v5 v5.0.0 // indirect
 )

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -15,7 +15,7 @@ title = 'Test site for mod-hubspot'
     source = "layouts"
     target = "layouts"
   [[module.imports]]
-    path = "github.com/gethinode/mod-hubspot/v2"
+    path = "github.com/gethinode/mod-hubspot/v4"
   [[module.imports.mounts]]
     source = "assets/js/modules/hubspot/hubspot.js"
     target = "assets/js/hubspot.js"
@@ -26,4 +26,8 @@ title = 'Test site for mod-hubspot'
     source = "layouts"
     target = "layouts"
   [[module.imports]]
-    path = "github.com/gethinode/mod-utils/v5"
+    path = "github.com/gethinode/mod-utils/v6"
+
+[params.modules.hubspot]
+  portal = 87654321
+  region = "na1"

--- a/exampleSite/mod-hubspot.work.sum
+++ b/exampleSite/mod-hubspot.work.sum
@@ -1,0 +1,2 @@
+github.com/gethinode/mod-utils/v6 v6.0.1 h1:EnmMHjqnI/xyHPXFj1SdRLfVxNunJcKLGVtSAAFTQ8w=
+github.com/gethinode/mod-utils/v6 v6.0.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/gethinode/mod-hubspot/v3
+module github.com/gethinode/mod-hubspot/v4
 
 go 1.19
 
-require github.com/gethinode/mod-utils/v5 v5.23.4 // indirect
+require github.com/gethinode/mod-utils/v6 v6.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -100,3 +100,5 @@ github.com/gethinode/mod-utils/v5 v5.23.3 h1:ifcDyTYpmM6HBzc6SbpG+hJMSCfGTZKf/pl
 github.com/gethinode/mod-utils/v5 v5.23.3/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
 github.com/gethinode/mod-utils/v5 v5.23.4 h1:/lcKi1MJ2srGfNhCPtdnTRpQgdh2FNBRUAS7Ysz1W34=
 github.com/gethinode/mod-utils/v5 v5.23.4/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
+github.com/gethinode/mod-utils/v6 v6.0.1 h1:EnmMHjqnI/xyHPXFj1SdRLfVxNunJcKLGVtSAAFTQ8w=
+github.com/gethinode/mod-utils/v6 v6.0.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=

--- a/layouts/_partials/assets/form.html
+++ b/layouts/_partials/assets/form.html
@@ -6,20 +6,30 @@
 
 {{- $error := false -}}
 
-{{/* Initialize arguments */}}
-{{- $args := partial "utilities/InitArgs.html" (dict "structure" "form" "args" . "group" "partial") -}}
-{{- if or $args.err $args.warnmsg -}}
-    {{- partial (cond $args.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict 
-        "partial" "assets/form.html" 
+{{/*
+    Initialize arguments. This is the public component partial invocable directly by Hinode/
+    other modules with page-content-derived values (the shortcode is only one caller), so it
+    validates non-strict like a site-authored-content entry point.
+*/}}
+{{- $result := partial "utilities/Args.html" (dict "structure" "form" "args" . "group" "partial" "strict" false) -}}
+{{- $args := $result.args -}}
+{{- if or $result.err $result.warnmsg -}}
+    {{- partial (cond $result.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict
+        "partial" "assets/form.html"
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
-        "details" ($args.errmsg | append $args.warnmsg)
+        "details" ($result.errmsg | append $result.warnmsg)
         "file"    page.File
     ) -}}
-    {{- $error = $args.err -}}
+    {{- $error = $result.err -}}
 {{- end -}}
 
-{{/* Initialize local arguments */}}
+{{/*
+    Initialize local arguments. "portal" and "region" have no schema default/config, so a plain
+    "default" fallback to the site-wide hubspot settings is safe here. "form-id" and its
+    deprecated twin "id" camelize to distinct keys (formId, id), so they are not merged by the
+    envelope and still need this explicit fallback.
+*/}}
 {{ $portal := $args.portal | default site.Params.modules.hubspot.portal }}
 {{ $region := $args.region | default site.Params.modules.hubspot.region }}
 {{ $id := or $args.formId $args.id }}

--- a/layouts/_shortcodes/form.html
+++ b/layouts/_shortcodes/form.html
@@ -6,21 +6,31 @@
 
 {{ $error := false }}
 
-{{/* Validate and initialize arguments */}}
-{{ $args := partial "utilities/InitArgs.html" (dict "structure" "form" "args" .Params "named" .IsNamedParams "group" "shortcode") }}
-{{ if or $args.err $args.warnmsg }}
-    {{ partial (cond $args.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict 
-        "partial"  "shortcodes/form.html" 
+{{/*
+    Validate and initialize arguments. This shortcode is a user-facing entry point receiving
+    raw page-content arguments, so it validates non-strict.
+*/}}
+{{ $result := partial "utilities/Args.html" (dict "structure" "form" "args" .Params "named" .IsNamedParams "group" "shortcode" "strict" false) }}
+{{ $args := $result.args }}
+{{ if or $result.err $result.warnmsg }}
+    {{ partial (cond $result.err "utilities/LogErr.html" "utilities/LogWarn.html") (dict
+        "partial"  "shortcodes/form.html"
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
-        "details"  ($args.errmsg | append $args.warnmsg)
+        "details"  ($result.errmsg | append $result.warnmsg)
         "file"     page.File
         "position" .Position
     )}}
-    {{ $error = $args.err }}
+    {{ $error = $result.err }}
 {{ end }}
 
-{{/* Initialize local arguments */}}
+{{/*
+    Initialize local arguments. "portal" and "region" have no schema default/config, so a plain
+    "default" fallback to the site-wide hubspot settings is safe here (nothing was pre-applied
+    by Args.html for these two). "form-id" and its deprecated twin "id" camelize to distinct
+    keys (formId, id), so they are not merged by the envelope and still need this explicit
+    fallback.
+*/}}
 {{ $portal := $args.portal | default site.Params.modules.hubspot.portal }}
 {{ $region := $args.region | default site.Params.modules.hubspot.region }}
 {{ $id := or $args.formId $args.id }}


### PR DESCRIPTION
## Summary

Adopts [mod-utils v6](https://github.com/gethinode/mod-utils/releases/tag/v6.0.1) (gethinode/mod-utils#334), the argument/type validation engine redesign, as this module's own major release (v3 → v4). Part of the [mod-utils v6 adoption program](https://github.com/gethinode/hinode/blob/main/docs/superpowers/specs/2026-07-12-mod-utils-v6-adoption-program-driver.md) (wave 1).

- **Go path bump:** `github.com/gethinode/mod-hubspot/v3` → `/v4`; `mod-utils` requirement bumped to `v6.0.1` (never `v6.0.0`, which carries a camelKey-defaulting defect fixed in `6.0.1`).
- **Hugo config / self-references:** `config.toml` (mod-utils import) updated to the new major. `exampleSite/hugo.toml` also fixed a pre-existing drift: its `module.imports` path pointed at the module's own stale `/v2` (the repo had already moved to `/v3` in `go.mod`) — now correctly `/v4`. No versioned references remained in `README.md`.
- **Argument handling migrated to `Args.html`** (see the [v5-to-v6 migration notes](https://github.com/gethinode/mod-utils/blob/main/README.md#migrating-from-v5-to-v6)), with the strict-false guardrail on both call sites — both accept site-authored values:
  - `layouts/_shortcodes/form.html`
  - `layouts/_partials/assets/form.html` (public component partial invocable directly with page-content-derived values, so also validated non-strict, matching the convention used for mod-fontawesome's `assets/icon.html` and mod-lottie's `assets/animation.html` in this same wave)

### Call-site fixes carried in this PR (recipe step 5c)

None needed. Both `portal` and `region` carry no schema `default`/`config` in `mod-utils`' global `_arguments.yml`, so the existing `$args.portal | default site.Params.modules.hubspot.portal` fallback is unaffected by v6's earlier-applied top-level defaults — there is nothing for it to silently fight. `form-id` and its deprecated twin `id` camelize to *distinct* keys (`formId` / `id`, not a kebab/snake collision on the same key), so the existing `or $args.formId $args.id` merge is still required and is not obviated by the v6 envelope's same-camelKey deprecated-twin handling.

Verified this is truly behavior-preserving, not just "no warnings appeared": built the same seeded exampleSite content against the pre-migration code (`InitArgs.html`, mod-utils v5) and the migrated code (`Args.html`, mod-utils v6) and diffed the rendered `index.html` byte-for-byte — **zero difference**.

### exampleSite content (recipe step 4d exercise gate)

`exampleSite/content/_index.md` was a placeholder with no shortcode calls at all (0 pages ever exercised the `form` shortcode). Seeded three demos:

1. Explicit `form-id`, `portal`, `region` (named arguments).
2. Positional `form-id` only, relying on the site-wide `params.modules.hubspot.portal`/`region` fallback (added to `exampleSite/hugo.toml`) — exercises the `| default site.Params...` path end to end.
3. The deprecated `id` argument in place of `form-id` — exercises the deprecation-warning path end to end.

## Test plan

- [x] `hugo mod graph` (exampleSite context) shows `github.com/gethinode/mod-hubspot/v4 → github.com/gethinode/mod-utils/v6@v6.0.1+vendor`, zero `/v5` references anywhere in the graph
- [x] `pnpm build` (`hugo --gc --minify -s exampleSite`) exits 0 with zero ERROR lines
- [x] Only one WARN line attributable to this module's own shortcode/partial: the intentional deprecation warning from demo 3 (`[form] argument 'id': deprecated in v1.0.0, use 'form-id' instead`) — expected, not a bug. The other WARN line (`.Site.Data` deprecated) is a pre-existing Hugo-core warning, unchanged from the pre-migration baseline build.
- [x] Every migrated call site exercised by the exampleSite: all three demos exercise the shortcode → partial chain, covering explicit args, the site-config fallback, and the deprecated-argument path
- [x] Byte-for-byte HTML diff between pre-migration and migrated engine for the same seeded content: identical (see above)
- [x] Visual regression: own exampleSite shot before/after (harness: `tests/visual/` on the hinode `program/mod-utils-v6-adoption` branch), 3 pages compared, 1 flagged (`index.png`, 0.5249%) — triaged **intended**: the diff image shows only the three new demo `<h2>` headings added to exercise the migrated shortcode (recipe step 4d); the associated `<div class="form">` embed placeholders render empty in both baseline and candidate (HubSpot's embed script is external and blocked by the harness), so no other pixels changed. The other 2 pages (`categories.png`, `tags.png`) were unflagged (0.0000%).
- [x] `git diff` reviewed file-by-file; no unrelated changes
- [x] Commit-body landmine check (`git show -s --format=%B HEAD | grep -E '^-.*-$'`) returns nothing
- [x] Pre-commit hooks (`pnpm test` build gate, commitlint) passed on the real commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
